### PR TITLE
Fix get_exchange_value

### DIFF
--- a/server.py
+++ b/server.py
@@ -312,12 +312,13 @@ def get_exchange(coin1, coin2):
 @app.route('/<coin1>/<float:n>/to/<coin2>/')
 def get_exchange_value(coin1, coin2, n):
     c = Coin(coin1)
+    v = c.value(coin2)
     return jsonify(coin={
         # 'name': c.name,
         # 'ticker': c.ticker,
-        'value': c.value(coin2) * n,
-        'value.currency': 'USD',
-        'exchange_rate': c.value(coin2)
+        'value': v * n,
+        'value.currency': coin2,
+        'exchange_rate': v
     })
 
 


### PR DESCRIPTION
This pull request fixes two problems in get_exchange_value:

1. value.currency was always USD. To fix this, coin2 is returned as the value of value.currency.
2. An extra API request was made, because Coin.value was called twice. Now coin2's value is stored in a variable to avoid this.

Testing performed:
* Called /btc/1/to/xmr/ and ensured currency.value was xmr.

Possible problems:
The CoinMarketCap API seems to be case insensitive. If I call this from curl and write XMR instead of xmr, I'll get XMR back.
If this is something to worry about normalizing, the API returns a symbol for coins. I can modify Coin.get_value to take a Coin and use the provided symbol if that would work better.